### PR TITLE
Measure between whole iterations of the event loop

### DIFF
--- a/test/eventLoopStats.js
+++ b/test/eventLoopStats.js
@@ -23,4 +23,21 @@ describe('eventLoopStats', function() {
     }, 1000);
   });
 
+  it('should actually detect a blocked eventloop', function(done) {
+    // Get stats to reset max
+    eventLoopStats.sense();
+    // On the next tick, block for 500ms
+    setTimeout(function() {
+      var waitUntill = new Date(Date.now() + 500);
+      while(waitUntill > new Date()) {};
+
+      // On the next tick, detect stats again
+      setTimeout(function() {
+        var stats = eventLoopStats.sense();
+        expect(stats.max).to.be.gt(450);
+        done();
+      }, 0);
+    }, 0)
+  });
+
 });


### PR DESCRIPTION
@paddybyers @mattheworiordan 

Context: https://github.com/ably/realtime/issues/1130 . Measures from check_handlers on one iteration to check_handles on the next, rather than from loop time update to check_handles on one iteration.

I don't know why the original approach doesn't work. Looking at http://docs.libuv.org/en/v1.x/design.html#the-i-o-loop , seems like it *should* work. But it doesn't seem to.

Before this change, with an artificial large `for` loop:
```
stats { min: 0, max: 12, num: 8623, sum: 99 }
stats { min: 0, max: 4, num: 4468, sum: 28 }
staring artificial delay
finished artificial delay
Detected huge event loop iteration (6190ms)!
stats { min: 0, max: 4, num: 3657, sum: 15 }
stats { min: 0, max: 4, num: 4396, sum: 25 }
```

After:
```
stats { min: 0, max: 9, num: 4477, sum: 5000 }
stats { min: 0, max: 23, num: 4484, sum: 5000 }
staring artificial delay
finished artificial delay
Detected huge event loop iteration (6407ms)!
stats { min: 0, max: 6185, num: 2902, sum: 9414 }
stats { min: 0, max: 10, num: 486, sum: 562 }
stats { min: 0, max: 23, num: 4452, sum: 4999 }
```